### PR TITLE
Fix out of bounds in CoordinateParser if chars is empty

### DIFF
--- a/Source/Paths/CoordinateParser.cs
+++ b/Source/Paths/CoordinateParser.cs
@@ -31,7 +31,7 @@ namespace Svg
             CharsPosition = 0;
             Position = 0;
             HasMore = chars.Length > 0;
-            if (char.IsLetter(chars[0])) ++CharsPosition;
+            if (HasMore && char.IsLetter(chars[0])) ++CharsPosition;
         }
     }
 


### PR DESCRIPTION
#### What does this implement/fix?
If the coordinate is `""` empty string, like in `<polyline stroke="url(#colorCountlines)" points="" />`
chars is empty.
The code already checks if it's empty and puts the result into `HasMore`.
But if it actually is empty, and `HasMore` is false, we still try to read chars[0] which will be a out-of-bounds read.